### PR TITLE
Fix handling multibyte characters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
 
 file :mruby do
-  sh "git clone git://github.com/mruby/mruby.git"
+  sh "git clone --depth 1 git://github.com/mruby/mruby.git"
 end
 
 desc "compile binary"
@@ -11,7 +11,7 @@ end
 
 desc "test"
 task :test => :mruby do
-  sh "cd mruby && MRUBY_CONFIG=#{MRUBY_CONFIG} rake all test"
+  sh "cd mruby && MRUBY_CONFIG=#{MRUBY_CONFIG} rake test"
 end
 
 desc "cleanup"

--- a/build_config.rb
+++ b/build_config.rb
@@ -3,3 +3,14 @@ MRuby::Build.new do |conf|
 
   conf.gem File.expand_path(File.dirname(__FILE__))
 end
+
+MRuby::Build.new('test') do |conf|
+  toolchain :gcc
+
+  enable_debug
+  #conf.enable_bintest
+  conf.enable_test
+
+  conf.gembox 'default'
+  conf.gem File.expand_path(File.dirname(__FILE__))
+end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -8,5 +8,6 @@ MRuby::Gem::Specification.new('mruby-uri') do |spec|
   spec.add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
   spec.add_dependency 'mruby-onig-regexp', mgem: 'mruby-onig-regexp'
   spec.add_dependency 'mruby-io', mgem: 'mruby-io'
+  spec.add_dependency 'mruby-pack', mgem: 'mruby-pack'
   spec.add_dependency 'mruby-mtest', mgem: 'mruby-mtest'
 end

--- a/mrblib/common.rb
+++ b/mrblib/common.rb
@@ -635,7 +635,14 @@ module URI
         end
       end
     end
-    str.gsub(/[^*\-.0-9A-Z_a-z]/){ TBLENCWWWCOMP_[$&] }
+    str.gsub(/[^*\-.0-9A-Z_a-z]/){
+      key = $&
+      if TBLENCWWWCOMP_[key]
+        TBLENCWWWCOMP_[key]
+      else
+        key.unpack("C*").collect{|i| "%%%X" % i }.join("")
+      end
+    }
   end
 
   # Decode given +str+ of URL-encoded form data.

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -61,10 +61,10 @@ class TestCommon < MTest::Unit::TestCase
     assert_equal("a=1", URI.encode_www_form([["a", "1"]]))
     assert_equal("a=1", URI.encode_www_form([[:a, 1]]))
     expected = "a=1&%E3%81%82=%E6%BC%A2"
-    assert_equal(expected, URI.encode_www_form("a" => "1", "\u3042" => "\u6F22"))
-    assert_equal(expected, URI.encode_www_form(a: 1, :"\u3042" => "\u6F22"))
-    assert_equal(expected, URI.encode_www_form([["a", "1"], ["\u3042", "\u6F22"]]))
-    assert_equal(expected, URI.encode_www_form([[:a, 1], [:"\u3042", "\u6F22"]]))
+    assert_equal(expected, URI.encode_www_form("a" => "1", 'あ' => '漢'))
+    assert_equal(expected, URI.encode_www_form(a: 1, :'あ' => '漢'))
+    assert_equal(expected, URI.encode_www_form([["a", "1"], ['あ', '漢']]))
+    assert_equal(expected, URI.encode_www_form([[:a, 1], [:'あ', '漢']]))
   end
 end
 


### PR DESCRIPTION
I hope that this patch makes `rake test` green.

* use String#unpack to encode multibyte characters
* mruby do not support notation `\uXXXX`, so use Unicode characters directly
* use shallow copy when getting mruby source