### PR TITLE
fix URI.encode_www_component("\x00")

### DIFF
--- a/mrblib/common.rb
+++ b/mrblib/common.rb
@@ -635,7 +635,7 @@ module URI
           TBLENCWWWCOMP_[' '] = '+'
         when 0x2A, 0x2D, 0x2E, 0x30..0x39, 0x41..0x5A, 0x5F, 0x61..0x7A
         else
-          TBLENCWWWCOMP_[i.chr] = '%%%X' % i
+          TBLENCWWWCOMP_[i.chr] = '%%%02X' % i
         end
       end
     end
@@ -644,7 +644,7 @@ module URI
       if TBLENCWWWCOMP_[key]
         TBLENCWWWCOMP_[key]
       else
-        key.unpack("C*").collect{|i| "%%%X" % i }.join("")
+        key.unpack("C*").collect{|i| "%%%02X" % i }.join("")
       end
     }
   end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -47,12 +47,16 @@ class TestCommon < MTest::Unit::TestCase
   def test_encode_www_component
     assert_equal("+%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E",
                  URI.encode_www_component(" !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~"))
+    assert_equal("%00%01", URI.encode_www_component("\x00\x01"))
+    assert_equal("%AA%FF", URI.encode_www_component("\xaa\xff"))
   end
 
   def test_decode_www_component
     assert_equal(" !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~",
                  URI.decode_www_component(
                    "+%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E"))
+    assert_equal("\x00\x01", URI.decode_www_component("%00%01"))
+    assert_equal("\xaa\xff", URI.decode_www_component("%AA%FF"))
   end
 
   def test_encode_www_form


### PR DESCRIPTION
`URI.encode_www_component("\x00")` should be `"%00"`, not `"%0"`
