### PR TITLE
Fix NoMethodError when $~[n] is nil

### DIFF
--- a/mrblib/common.rb
+++ b/mrblib/common.rb
@@ -384,15 +384,8 @@ module URI
       # null uri
 
     when ABS_URI
-      scheme    = $~[1].empty? ? nil : $~[1]
-      opaque    = $~[2].empty? ? nil : $~[2]
-      userinfo  = $~[3].empty? ? nil : $~[3]
-      host      = $~[4].empty? ? nil : $~[4]
-      port      = $~[5].empty? ? nil : $~[5]
-      registry  = $~[6].empty? ? nil : $~[6]
-      path      = $~[7].empty? ? nil : $~[7]
-      query     = $~[8].empty? ? nil : $~[8]
-      fragment  = $~[-1].empty? ? nil : $~[-1]
+      scheme, opaque, userinfo, host, port,
+          registry, path, query, fragment = $~[1..-1]
 
       # URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
 
@@ -419,15 +412,8 @@ module URI
       scheme = nil
       opaque = nil
 
-      userinfo      = $~[1].empty? ? nil : $~[1]
-      host          = $~[2].empty? ? nil : $~[2]
-      port          = $~[3].empty? ? nil : $~[3]
-      registry      = $~[4].empty? ? nil : $~[4]
-      rel_segment   = $~[5].empty? ? nil : $~[5]
-      abs_path      = $~[6].empty? ? nil : $~[6]
-      query         = $~[7].empty? ? nil : $~[7]
-      fragment      = $~[-1].empty? ? nil : $~[-1]
-
+      userinfo, host, port, registry,
+        rel_segment, abs_path, query, fragment = $~[1..-1]
       if rel_segment && abs_path
         path = rel_segment + abs_path
       elsif rel_segment


### PR DESCRIPTION
```
$ git rev-parse HEAD
f022496308904e283a536e7afdae4ea644c7b96c

$ rake test
...snip...
>>> Test test <<<
mrbtest - Embeddable Ruby Test

.......S...
# Running tests:

.E....

Finished tests in 0.008243s, 727.8903 tests/s, 3639.4517 assertions/s.

  1) Error:
test_kernel_uri(TestCommon): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

6 tests, 30 assertions, 0 failures, 1 errors, 0 skips

# Running tests:

EEEEEE

Finished tests in 0.002821s, 2126.9054 tests/s, 0.0000 assertions/s.

  1) Error:
test_route(TestGeneric): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  2) Error:
test_merge(TestGeneric): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  3) Error:
test_join(TestGeneric): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  4) Error:
test_rfc3986_examples(TestGeneric): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  5) Error:
test_parse(TestGeneric): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  6) Error:
test_set_component(TestGeneric): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

6 tests, 0 assertions, 0 failures, 6 errors, 0 skips

# Running tests:

EEEEE

Finished tests in 0.001263s, 3958.8282 tests/s, 0.0000 assertions/s.

  1) Error:
test_equal(TestHTTP): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  2) Error:
test_normalize(TestHTTP): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  3) Error:
test_select(TestHTTP): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  4) Error:
test_request_uri(TestHTTP): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

  5) Error:
test_parse(TestHTTP): NoMethodError, /Users/ksss/src/github.com/ksss/mruby-uri/mrblib/common.rb:388: undefined method 'empty?' for nil (NoMethodError)

5 tests, 0 assertions, 0 failures, 5 errors, 0 skips
.........................................................................................?..........................................................................................................................................................................................................................................................................................................................?............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................?.........................................................................................................................................................................................
Skip: Struct.new removes existing constant  redefining Struct with same name cause warnings
Skip: File.expand_path (with ENV)
MTest 1) Skipped:
test_assert_match(Test4MTest) /Users/ksss/src/github.com/ksss/mruby-uri/mruby/build/mrbgems/mruby-mtest/test/mtest_unit_test.rb:51: assert_match is not defined, because Regexp is not impl. (MTest::Skip)

Skip: Module#prepend super in alias  super does not currently work in aliased methods
Total: 1107
   OK: 1095
   KO: 0
Crash: 12
 Time: 0.47 seconds
rake aborted!
Command failed with status (1): ["build/test/bin/mrbtest"...]
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/tasks/mruby_build.rake:283:in `run_test'
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/Rakefile:121:in `block (2 levels) in <top (required)>'
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/tasks/mruby_build.rake:13:in `instance_eval'
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/tasks/mruby_build.rake:13:in `block in each_target'
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/tasks/mruby_build.rake:12:in `each'
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/tasks/mruby_build.rake:12:in `each_target'
/Users/ksss/src/github.com/ksss/mruby-uri/mruby/Rakefile:120:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [cd mruby && MRUBY_CONFIG=/Users/ksss/src/g...]
/Users/ksss/src/github.com/ksss/mruby-uri/Rakefile:14:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

```
$ git rev-parse HEAD
54c8a75da991b421967d76dfc79ef233dcaa48a1

$ rake test
...snip...
>>> Test test <<<
mrbtest - Embeddable Ruby Test

.......S...
# Running tests:

......

Finished tests in 0.008426s, 712.0817 tests/s, 3797.7688 assertions/s.

6 tests, 32 assertions, 0 failures, 0 errors, 0 skips

# Running tests:

......

Finished tests in 0.020958s, 286.2869 tests/s, 13598.6258 assertions/s.

6 tests, 285 assertions, 0 failures, 0 errors, 0 skips

# Running tests:

.....

Finished tests in 0.001697s, 2946.3760 tests/s, 11196.2286 assertions/s.

5 tests, 19 assertions, 0 failures, 0 errors, 0 skips
.........................................................................................?..........................................................................................................................................................................................................................................................................................................................?............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................?.........................................................................................................................................................................................
Skip: Struct.new removes existing constant  redefining Struct with same name cause warnings
Skip: File.expand_path (with ENV)
MTest 1) Skipped:
test_assert_match(Test4MTest) /Users/ksss/src/github.com/ksss/mruby-uri/mruby/build/mrbgems/mruby-mtest/test/mtest_unit_test.rb:51: assert_match is not defined, because Regexp is not impl. (MTest::Skip)

Skip: Module#prepend super in alias  super does not currently work in aliased methods
Total: 1107
   OK: 1107
   KO: 0
Crash: 0
 Time: 0.55 seconds
```