### PR TITLE
Update dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,10 +4,8 @@ MRuby::Gem::Specification.new('mruby-uri') do |spec|
   spec.summary = 'Extension for handling URI in mruby'
 
   spec.add_dependency 'mruby-string-ext', core: 'mruby-string-ext'
-  spec.add_dependency 'mruby-numeric-ext', core: 'mruby-numeric-ext'
   spec.add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
   spec.add_dependency 'mruby-onig-regexp', mgem: 'mruby-onig-regexp'
-  spec.add_dependency 'mruby-io', mgem: 'mruby-io'
   spec.add_dependency 'mruby-pack', mgem: 'mruby-pack'
-  spec.add_dependency 'mruby-mtest', mgem: 'mruby-mtest'
+  spec.add_test_dependency 'mruby-mtest', mgem: 'mruby-mtest'
 end


### PR DESCRIPTION
`mruby-numeric-ext` and `mruby-io` seems no longer used.
And `mruby-mtest` is using only testing.