### PR TITLE
Rename from {en,de}code_www_component to {en,de}code_www_form_component

### DIFF
--- a/mrblib/common.rb
+++ b/mrblib/common.rb
@@ -624,8 +624,8 @@ module URI
   #
   # This refers http://www.w3.org/TR/html5/forms.html#url-encoded-form-data
   #
-  # See URI.decode_www_component(str), URI.encode_www_form(enum)
-  def self.encode_www_component(str)
+  # See URI.decode_www_form_component(str), URI.encode_www_form(enum)
+  def self.encode_www_form_component(str)
     str.to_s.gsub(/[^*\-.0-9A-Z_a-z]/n) { TBLENCWWWCOMP_[$&] }
   end
 
@@ -633,8 +633,8 @@ module URI
   #
   # This decods + to SP.
   #
-  # See URI.encode_www_component(str)
-  def self.decode_www_component(str)
+  # See URI.encode_www_form_component(str)
+  def self.decode_www_form_component(str)
     str.gsub(/\+|%\h\h/){ TBLDECWWWCOMP_[$&] }
   end
 
@@ -643,7 +643,7 @@ module URI
   # This generates application/x-www-form-urlencoded data defined in HTML5
   # from given an Enumerable object.
   #
-  # This internally uses URI.encode_www_component(str).
+  # This internally uses URI.encode_www_form_component(str).
   #
   # This doesn't convert encodings of give items, so convert them before call
   # this method if you want to send data as other than original encoding or
@@ -653,23 +653,23 @@ module URI
   #
   # This refers http://www.w3.org/TR/html5/forms.html#url-encoded-form-data
   #
-  # See URI.encode_www_component(str)
+  # See URI.encode_www_form_component(str)
   def self.encode_www_form(enum)
     enum.map do |k, v|
       if v.nil?
-        encode_www_component(k)
+        encode_www_form_component(k)
       elsif v.respond_to?(:to_ary)
         v.to_ary.map do |w|
-          str = encode_www_component(k)
+          str = encode_www_form_component(k)
           unless w.nil?
             str << '='
-            str << encode_www_component(w)
+            str << encode_www_form_component(w)
           end
         end.join('&')
       else
-        str = encode_www_component(k)
+        str = encode_www_form_component(k)
         str << '='
-        str << encode_www_component(v)
+        str << encode_www_form_component(v)
       end
     end.join("&")
   end
@@ -682,8 +682,8 @@ module URI
       key, val = string.split('=', 2)
 
       [
-        key.nil? ? "" : decode_www_component(key),
-        val.nil? ? "" : decode_www_component(val),
+        key.nil? ? "" : decode_www_form_component(key),
+        val.nil? ? "" : decode_www_form_component(val),
       ]
     end
   end

--- a/src/uri.c
+++ b/src/uri.c
@@ -1,0 +1,34 @@
+#include <mruby.h>
+
+static mrb_value
+mrb_uri_s_encode_www_component(mrb_state *mrb, mrb_value uri)
+{
+  mrb_value *argv;
+  mrb_int argc;
+  mrb_warn(mrb, "[Deprecated] Please use `URI.encode_www_form_component' instead of `URI.encode_www_component' \n");
+  mrb_get_args(mrb, "*", &argv, &argc);
+  return mrb_funcall_argv(mrb, uri, mrb_intern_lit(mrb, "encode_www_form_component"), argc, argv);
+}
+
+static mrb_value
+mrb_uri_s_decode_www_component(mrb_state *mrb, mrb_value uri)
+{
+  mrb_value *argv;
+  mrb_int argc;
+  mrb_warn(mrb, "[Deprecated] Please use `URI.decode_www_form_component' instead of `URI.decode_www_component' \n");
+  mrb_get_args(mrb, "*", &argv, &argc);
+  return mrb_funcall_argv(mrb, uri, mrb_intern_lit(mrb, "decode_www_form_component"), argc, argv);
+}
+
+void
+mrb_mruby_uri_gem_init(mrb_state *mrb)
+{
+  struct RClass *uri = mrb_define_module(mrb, "URI");
+  mrb_define_class_method(mrb, uri, "encode_www_component", mrb_uri_s_encode_www_component, MRB_ARGS_ANY());
+  mrb_define_class_method(mrb, uri, "decode_www_component", mrb_uri_s_decode_www_component, MRB_ARGS_ANY());
+}
+
+void
+mrb_mruby_uri_gem_final(mrb_state *mrb)
+{
+}

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -44,19 +44,19 @@ class TestCommon < MTest::Unit::TestCase
     #assert_raise(NoMethodError) { Object.new.URI("http://www.ruby-lang.org/") }
   end
 
-  def test_encode_www_component
+  def test_encode_www_form_component
     assert_equal("+%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E",
-                 URI.encode_www_component(" !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~"))
-    assert_equal("%00%01", URI.encode_www_component("\x00\x01"))
-    assert_equal("%AA%FF", URI.encode_www_component("\xaa\xff"))
+                 URI.encode_www_form_component(" !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~"))
+    assert_equal("%00%01", URI.encode_www_form_component("\x00\x01"))
+    assert_equal("%AA%FF", URI.encode_www_form_component("\xaa\xff"))
   end
 
-  def test_decode_www_component
+  def test_decode_www_form_component
     assert_equal(" !\"\#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~",
-                 URI.decode_www_component(
+                 URI.decode_www_form_component(
                    "+%21%22%23%24%25%26%27%28%29*%2B%2C-.%2F09%3A%3B%3C%3D%3E%3F%40AZ%5B%5C%5D%5E_%60az%7B%7C%7D%7E"))
-    assert_equal("\x00\x01", URI.decode_www_component("%00%01"))
-    assert_equal("\xaa\xff", URI.decode_www_component("%AA%FF"))
+    assert_equal("\x00\x01", URI.decode_www_form_component("%00%01"))
+    assert_equal("\xaa\xff", URI.decode_www_form_component("%AA%FF"))
   end
 
   def test_encode_www_form


### PR DESCRIPTION
{en,de}code_www_component was depreceted.
ref #11

```
> URI.encode_www_component("")
warning: [Deprecated] Please use `URI.encode_www_form_component' instead of `URI.encode_www_component'
 => ""
> URI.decode_www_component("")
warning: [Deprecated] Please use `URI.decode_www_form_component' instead of `URI.decode_www_component'
 => ""
```