### PR TITLE
Add mailto scheme

### DIFF
--- a/mrblib/generic.rb
+++ b/mrblib/generic.rb
@@ -106,7 +106,7 @@ module URI
     def self.build(args)
       if args.kind_of?(Array) &&
           args.size == ::URI::Generic::COMPONENT.size
-        tmp = args
+        tmp = args.dup
       elsif args.kind_of?(Hash)
         tmp = ::URI::Generic::COMPONENT.collect do |c|
           if args.include?(c)
@@ -116,8 +116,9 @@ module URI
           end
         end
       else
+        component = self.class.component rescue ::URI::Generic::COMPONENT
         raise ArgumentError,
-        "expected Array of or Hash of components of #{self.class} (#{self.class.component.join(', ')})"
+        "expected Array of or Hash of components of #{self.class} (#{component.join(', ')})"
       end
 
       tmp << true

--- a/mrblib/mailto.rb
+++ b/mrblib/mailto.rb
@@ -1,0 +1,285 @@
+# = uri/mailto.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+module URI
+
+  #
+  # RFC6068, The mailto URL scheme
+  #
+  class MailTo < Generic
+    include REGEXP
+
+    # A Default port of nil for URI::MailTo
+    DEFAULT_PORT = nil
+
+    # An Array of the available components for URI::MailTo
+    COMPONENT = [ :scheme, :to, :headers ].freeze
+
+    # :stopdoc:
+    #  "hname" and "hvalue" are encodings of an RFC 822 header name and
+    #  value, respectively. As with "to", all URL reserved characters must
+    #  be encoded.
+    #
+    #  "#mailbox" is as specified in RFC 822 [RFC822]. This means that it
+    #  consists of zero or more comma-separated mail addresses, possibly
+    #  including "phrase" and "comment" components. Note that all URL
+    #  reserved characters in "to" must be encoded: in particular,
+    #  parentheses, commas, and the percent sign ("%"), which commonly occur
+    #  in the "mailbox" syntax.
+    #
+    #  Within mailto URLs, the characters "?", "=", "&" are reserved.
+
+    # ; RFC 6068
+    # hfields      = "?" hfield *( "&" hfield )
+    # hfield       = hfname "=" hfvalue
+    # hfname       = *qchar
+    # hfvalue      = *qchar
+    # qchar        = unreserved / pct-encoded / some-delims
+    # some-delims  = "!" / "$" / "'" / "(" / ")" / "*"
+    #              / "+" / "," / ";" / ":" / "@"
+    #
+    # ; RFC3986
+    # unreserved   = ALPHA / DIGIT / "-" / "." / "_" / "~"
+    # pct-encoded  = "%" HEXDIG HEXDIG
+    HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
+    # practical regexp for email address
+    # http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#valid-e-mail-address
+    EMAIL_REGEXP = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
+    # :startdoc:
+
+    #
+    # == Description
+    #
+    # Creates a new URI::MailTo object from components, with syntax checking.
+    #
+    # Components can be provided as an Array or Hash. If an Array is used,
+    # the components must be supplied as [to, headers].
+    #
+    # If a Hash is used, the keys are the component names preceded by colons.
+    #
+    # The headers can be supplied as a pre-encoded string, such as
+    # "subject=subscribe&cc=address", or as an Array of Arrays like
+    # [['subject', 'subscribe'], ['cc', 'address']]
+    #
+    # Examples:
+    #
+    #    require 'uri'
+    #
+    #    m1 = URI::MailTo.build(['joe@example.com', 'subject=Ruby'])
+    #    puts m1.to_s  ->  mailto:joe@example.com?subject=Ruby
+    #
+    #    m2 = URI::MailTo.build(['john@example.com', [['Subject', 'Ruby'], ['Cc', 'jack@example.com']]])
+    #    puts m2.to_s  ->  mailto:john@example.com?Subject=Ruby&Cc=jack@example.com
+    #
+    #    m3 = URI::MailTo.build({:to => 'listman@example.com', :headers => [['subject', 'subscribe']]})
+    #    puts m3.to_s  ->  mailto:listman@example.com?subject=subscribe
+    #
+    def self.build(args)
+      tmp = Util.make_components_hash(self, args)
+
+      case tmp[:to]
+      when Array
+        tmp[:opaque] = tmp[:to].join(',')
+      when String
+        tmp[:opaque] = tmp[:to].dup
+      else
+        tmp[:opaque] = ''
+      end
+
+      if tmp[:headers]
+        query =
+          case tmp[:headers]
+          when Array
+            tmp[:headers].collect { |x|
+              if x.kind_of?(Array)
+                x[0] + '=' + x[1..-1].join
+              else
+                x.to_s
+              end
+            }.join('&')
+          when Hash
+            tmp[:headers].collect { |h,v|
+              h + '=' + v
+            }.join('&')
+          else
+            tmp[:headers].to_s
+          end
+        unless query.empty?
+          tmp[:opaque] << '?' << query
+        end
+      end
+
+      super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new URI::MailTo object from generic URL components with
+    # no syntax checking.
+    #
+    # This method is usually called from URI::parse, which checks
+    # the validity of each component.
+    #
+    def initialize(*arg)
+      super(*arg)
+
+      @to = nil
+      @headers = []
+
+      # The RFC3986 parser does not normally populate opaque
+      @opaque = "?#{@query}" if @query && !@opaque
+
+      unless @opaque
+        raise InvalidComponentError,
+          "missing opaque part for mailto URL"
+      end
+      to, header = @opaque.split('?', 2)
+      # allow semicolon as a addr-spec separator
+      # http://support.microsoft.com/kb/820868
+      unless /\A(?:[^@,;]+@[^@,;]+(?:\z|[,;]))*\z/ =~ to
+        raise InvalidComponentError,
+          "unrecognised opaque part for mailtoURL: #{@opaque}"
+      end
+      self.to = to
+      self.headers = header
+    end
+
+    # The primary e-mail address of the URL, as a String
+    attr_reader :to
+
+    # E-mail headers set by the URL, as an Array of Arrays
+    attr_reader :headers
+
+    # check the to +v+ component
+    def check_to(v)
+      return true unless v
+      return true if v.size == 0
+
+      v.split(/[,;]/).each do |addr|
+        # check url safety as path-rootless
+        if /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*\z/ !~ addr
+          raise InvalidComponentError,
+            "an address in 'to' is invalid as URI #{addr.dump}"
+        end
+
+        # check addr-spec
+        # don't s/\+/ /g
+        addr.gsub!(/%\h\h/, URI::TBLDECWWWCOMP_)
+        if EMAIL_REGEXP !~ addr
+          raise InvalidComponentError,
+            "an address in 'to' is invalid as uri-escaped addr-spec #{addr.dump}"
+        end
+      end
+
+      true
+    end
+    private :check_to
+
+    # private setter for to +v+
+    def set_to(v)
+      @to = v
+    end
+    protected :set_to
+
+    # setter for to +v+
+    def to=(v)
+      check_to(v)
+      set_to(v)
+      v
+    end
+
+    # check the headers +v+ component against either
+    # * HEADER_REGEXP
+    def check_headers(v)
+      return true unless v
+      return true if v.size == 0
+      if HEADER_REGEXP !~ v
+        raise InvalidComponentError,
+          "bad component(expected opaque component): #{v}"
+      end
+
+      true
+    end
+    private :check_headers
+
+    # private setter for headers +v+
+    def set_headers(v)
+      @headers = []
+      if v
+        v.split('&').each do |x|
+          @headers << x.split(/=/, 2)
+        end
+      end
+    end
+    protected :set_headers
+
+    # setter for headers +v+
+    def headers=(v)
+      check_headers(v)
+      set_headers(v)
+      v
+    end
+
+    # Constructs String from URI
+    def to_s
+      @scheme + ':' +
+        if @to
+          @to
+        else
+          ''
+        end +
+        if @headers.size > 0
+          '?' + @headers.collect{|x| x.join('=')}.join('&')
+        else
+          ''
+        end +
+        if @fragment
+          '#' + @fragment
+        else
+          ''
+        end
+    end
+
+    # Returns the RFC822 e-mail text equivalent of the URL, as a String.
+    #
+    # Example:
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("mailto:ruby-list@ruby-lang.org?Subject=subscribe&cc=myaddr")
+    #   uri.to_mailtext
+    #   # => "To: ruby-list@ruby-lang.org\nSubject: subscribe\nCc: myaddr\n\n\n"
+    #
+    def to_mailtext
+      to = URI.decode_www_form_component(@to)
+      head = ''
+      body = ''
+      @headers.each do |x|
+        case x[0]
+        when 'body'
+          body = URI.decode_www_form_component(x[1])
+        when 'to'
+          to << ', ' + URI.decode_www_form_component(x[1])
+        else
+          head << URI.decode_www_form_component(x[0]).capitalize + ': ' +
+            URI.decode_www_form_component(x[1])  + "\n"
+        end
+      end
+
+      "To: #{to}
+#{head}
+#{body}
+"
+    end
+    alias to_rfc822text to_mailtext
+  end
+
+  @@schemes['MAILTO'] = MailTo
+end

--- a/mrblib/mailto.rb
+++ b/mrblib/mailto.rb
@@ -19,7 +19,7 @@ module URI
     DEFAULT_PORT = nil
 
     # An Array of the available components for URI::MailTo
-    COMPONENT = [ :scheme, :to, :headers ].freeze
+    COMPONENT = [ :scheme, :to, :headers ]
 
     # :stopdoc:
     #  "hname" and "hvalue" are encodings of an RFC 822 header name and

--- a/test/test_mailto.rb
+++ b/test/test_mailto.rb
@@ -1,0 +1,189 @@
+class URI::TestMailTo < MTest::Unit::TestCase
+  def setup
+    @u = URI::MailTo
+  end
+
+  def teardown
+  end
+
+  def uri_to_ary(uri)
+    uri.class.component.collect {|c| uri.send(c)}
+  end
+
+  def test_build
+    ok = []
+    bad = []
+
+    # RFC2368, 6. Examples
+    # mailto:chris@example.com
+    ok << ["mailto:chris@example.com"]
+    ok[-1] << ["chris@example.com", nil]
+    ok[-1] << {:to => "chris@example.com"}
+
+    ok << ["mailto:foo+@example.com,bar@example.com"]
+    ok[-1] << [["foo+@example.com", "bar@example.com"], nil]
+    ok[-1] << {:to => "foo+@example.com,bar@example.com"}
+
+    # mailto:infobot@example.com?subject=current-issue
+    ok << ["mailto:infobot@example.com?subject=current-issue"]
+    ok[-1] << ["infobot@example.com", ["subject=current-issue"]]
+    ok[-1] << {:to => "infobot@example.com",
+      :headers => ["subject=current-issue"]}
+
+    # mailto:infobot@example.com?body=send%20current-issue
+    ok << ["mailto:infobot@example.com?body=send%20current-issue"]
+    ok[-1] << ["infobot@example.com", ["body=send%20current-issue"]]
+    ok[-1] << {:to => "infobot@example.com",
+      :headers => ["body=send%20current-issue"]}
+
+    # mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index
+    ok << ["mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index"]
+    ok[-1] << ["infobot@example.com",
+      ["body=send%20current-issue%0D%0Asend%20index"]]
+    ok[-1] << {:to => "infobot@example.com",
+      :headers => ["body=send%20current-issue%0D%0Asend%20index"]}
+
+    # mailto:foobar@example.com?In-Reply-To=%3c3469A91.D10AF4C@example.com
+    ok << ["mailto:foobar@example.com?In-Reply-To=%3c3469A91.D10AF4C@example.com"]
+    ok[-1] << ["foobar@example.com",
+      ["In-Reply-To=%3c3469A91.D10AF4C@example.com"]]
+    ok[-1] << {:to => "foobar@example.com",
+      :headers => ["In-Reply-To=%3c3469A91.D10AF4C@example.com"]}
+
+    # mailto:majordomo@example.com?body=subscribe%20bamboo-l
+    ok << ["mailto:majordomo@example.com?body=subscribe%20bamboo-l"]
+    ok[-1] << ["majordomo@example.com", ["body=subscribe%20bamboo-l"]]
+    ok[-1] << {:to => "majordomo@example.com",
+      :headers => ["body=subscribe%20bamboo-l"]}
+
+    # mailto:joe@example.com?cc=bob@example.com&body=hello
+    ok << ["mailto:joe@example.com?cc=bob@example.com&body=hello"]
+    ok[-1] << ["joe@example.com", ["cc=bob@example.com", "body=hello"]]
+    ok[-1] << {:to => "joe@example.com",
+      :headers => ["cc=bob@example.com", "body=hello"]}
+
+    # mailto:?to=joe@example.com&cc=bob@example.com&body=hello
+    ok << ["mailto:?to=joe@example.com&cc=bob@example.com&body=hello"]
+    ok[-1] << [nil,
+      ["to=joe@example.com", "cc=bob@example.com", "body=hello"]]
+    ok[-1] << {:headers => ["to=joe@example.com",
+	"cc=bob@example.com", "body=hello"]}
+
+    # mailto:gorby%25kremvax@example.com
+    ok << ["mailto:gorby%25kremvax@example.com"]
+    ok[-1] << ["gorby%25kremvax@example.com", nil]
+    ok[-1] << {:to => "gorby%25kremvax@example.com"}
+
+    # mailto:unlikely%3Faddress@example.com?blat=foop
+    ok << ["mailto:unlikely%3Faddress@example.com?blat=foop"]
+    ok[-1] << ["unlikely%3Faddress@example.com", ["blat=foop"]]
+    ok[-1] << {:to => "unlikely%3Faddress@example.com",
+      :headers => ["blat=foop"]}
+
+    # mailto:john@example.com?Subject=Ruby&Cc=jack@example.com
+    ok << ["mailto:john@example.com?Subject=Ruby&Cc=jack@example.com"]
+    ok[-1] << ['john@example.com', [['Subject', 'Ruby'], ['Cc', 'jack@example.com']]]
+    ok[-1] << {:to=>"john@example.com", :headers=>[["Subject", "Ruby"], ["Cc", "jack@example.com"]]}
+
+    # mailto:listman@example.com?subject=subscribe
+    ok << ["mailto:listman@example.com?subject=subscribe"]
+    ok[-1] << {:to => 'listman@example.com', :headers => [['subject', 'subscribe']]}
+    ok[-1] << {:to => 'listman@example.com', :headers => [['subject', 'subscribe']]}
+
+    # mailto:listman@example.com?subject=subscribe
+    ok << ["mailto:listman@example.com?subject=subscribe"]
+    ok[-1] << {:to => 'listman@example.com', :headers => { 'subject' => 'subscribe' }}
+    ok[-1] << {:to => 'listman@example.com', :headers => 'subject=subscribe' }
+
+    ok_all = ok.flatten.join("\0")
+
+    # mailto:joe@example.com?cc=bob@example.com?body=hello   ; WRONG!
+    bad << ["joe@example.com", ["cc=bob@example.com?body=hello"]]
+
+    # mailto:javascript:alert()
+    bad << ["javascript:alert()", []]
+
+    # mailto:/example.com/    ; WRONG, not a mail address
+    bad << ["/example.com/", []]
+
+    # '=' which is in hname or hvalue is wrong.
+    bad << ["foo@example.jp?subject=1+1=2", []]
+
+    ok.each do |x|
+      assert_equal(x[0], URI.parse(x[0]).to_s)
+      assert_equal(x[0], @u.build(x[1]).to_s)
+      assert_equal(x[0], @u.build(x[2]).to_s)
+    end
+
+    bad.each do |x|
+      assert_raise(URI::InvalidURIError) {
+        URI.parse(x)
+      }
+      assert_raise(URI::InvalidComponentError) {
+	@u.build(x)
+      }
+    end
+
+    assert_equal(ok_all, ok.flatten.join("\0"))
+  end
+
+  def test_initializer
+    assert_raise(URI::InvalidComponentError) do
+      URI::MailTo.new('mailto', 'sdmitry:bla', 'localhost', '2000', nil,
+                      'joe@example.com', nil, nil, 'subject=Ruby')
+    end
+  end
+
+  def test_check_to
+    u = URI::MailTo.build(['joe@example.com', 'subject=Ruby'])
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = '#1@mail.com'
+    end
+
+    assert_raise(URI::InvalidComponentError) do
+      u.to = '@invalid.email'
+    end
+  end
+
+  def test_to_s
+    u = URI::MailTo.build([nil, 'subject=Ruby'])
+
+    u.send(:set_to, nil)
+    assert_equal('mailto:?subject=Ruby', u.to_s)
+
+    u.fragment = 'test'
+    assert_equal('mailto:?subject=Ruby#test', u.to_s)
+  end
+
+  def test_to_mailtext
+    results = []
+    results << ["To: ruby-list@ruby-lang.org\nSubject: subscribe\n\n\n"]
+    results[-1] << { to: 'ruby-list@ruby-lang.org', headers: { 'subject' => 'subscribe' } }
+
+    results << ["To: ruby-list@ruby-lang.org\n\nBody\n"]
+    results[-1] << { to: 'ruby-list@ruby-lang.org', headers: { 'body' => 'Body' } }
+
+    results << ["To: ruby-list@ruby-lang.org, cc@ruby-lang.org\n\n\n"]
+    results[-1] << { to: 'ruby-list@ruby-lang.org', headers: { 'to' => 'cc@ruby-lang.org' } }
+
+    results.each do |expected, params|
+      u = URI::MailTo.build(params)
+      assert_equal(expected, u.to_mailtext)
+    end
+
+    u = URI.parse('mailto:ruby-list@ruby-lang.org?Subject=subscribe&cc=myaddr')
+    assert_equal "To: ruby-list@ruby-lang.org\nSubject: subscribe\nCc: myaddr\n\n\n",
+      u.to_mailtext
+  end
+
+  def test_select
+    u = URI.parse('mailto:joe@example.com?cc=bob@example.com&body=hello')
+    assert_equal(uri_to_ary(u), u.select(*u.component))
+    assert_raise(ArgumentError) do
+      u.select(:scheme, :host, :not_exist, :port)
+    end
+  end
+end
+
+MTest::Unit.new.run


### PR DESCRIPTION
I implemented mailto scheme.
We'll be able to check scheme for mailto uri.

```rb
URI.parse("mailto:ruby-list#ruby-lang.org")
#=> URI::InvalidComponentError: unrecognised opaque part for mailtoURL: ruby-list
```