### PR TITLE
Add dependency to metaprog

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,6 +3,7 @@ MRuby::Gem::Specification.new('mruby-uri') do |spec|
   spec.author  = 'zzak'
   spec.summary = 'Extension for handling URI in mruby'
 
+  spec.add_dependency 'mruby-metaprog', core: 'mruby-metaprog'
   spec.add_dependency 'mruby-string-ext', core: 'mruby-string-ext'
   spec.add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
   spec.add_dependency 'mruby-onig-regexp', mgem: 'mruby-onig-regexp'


### PR DESCRIPTION
Current latest mruby has introduced `mruby-metaprog` as a core mgem. Thanks!