### PR TITLE
Fix escape(str [, unsafe]), and unescape(str)

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,6 +5,13 @@ MRuby::Gem::Specification.new('mruby-uri') do |spec|
 
   spec.add_dependency 'mruby-string-ext', core: 'mruby-string-ext'
   spec.add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
+
+  if File.exist? "#{MRUBY_ROOT}/mrbgems/mruby-pack"
+    spec.add_dependency 'mruby-pack', core: 'mruby-pack'
+  else
+    spec.add_dependency 'mruby-pack', mgem: 'mruby-pack'
+  end
+
   spec.add_dependency 'mruby-onig-regexp', mgem: 'mruby-onig-regexp'
   spec.add_test_dependency 'mruby-mtest', mgem: 'mruby-mtest'
 end

--- a/mrblib/00_rfc2396_parser.rb
+++ b/mrblib/00_rfc2396_parser.rb
@@ -298,7 +298,7 @@ module URI
     def escape(str, unsafe = @regexp[:UNSAFE])
       unless unsafe.kind_of?(Regexp)
         # perhaps unsafe is String object
-        unsafe = Regexp.new("[#{Regexp.quote(unsafe)}]", false)
+        unsafe = Regexp.new("[#{Regexp.quote(unsafe)}]", nil)
       end
       str.gsub(unsafe) do
         us = $&
@@ -307,7 +307,7 @@ module URI
           tmp << sprintf('%%%02X', uc)
         end
         tmp
-      end.force_encoding(Encoding::US_ASCII)
+      end
     end
 
     #
@@ -327,7 +327,7 @@ module URI
     # Removes escapes from +str+
     #
     def unescape(str, escaped = @regexp[:ESCAPED])
-      str.gsub(escaped) { [$&[1, 2].hex].pack('C') }.force_encoding(str.encoding)
+      str.gsub(escaped) { [$&[1, 2].hex].pack('C') }
     end
 
     def inspect

--- a/mrblib/common.rb
+++ b/mrblib/common.rb
@@ -91,7 +91,7 @@ module URI
     #
     def escape(str, unsafe = UNSAFE)
       # URI.escape is obsolete"
-      DEFAULT_PARSER.escape(*arg)
+      DEFAULT_PARSER.escape(str, unsafe)
     end
     alias encode escape
     #
@@ -117,7 +117,7 @@ module URI
     #
     def unescape(str)
       # URI.unescape is obsolete
-      DEFAULT_PARSER.unescape(*arg)
+      DEFAULT_PARSER.unescape(str)
     end
     alias decode unescape
   end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -95,6 +95,15 @@ class TestCommon < MTest::Unit::TestCase
     assert_equal([%w[a 1], %w[b %]], URI.decode_www_form("a=1&b=%"))
     assert_equal([['a', ''], ['b', '']], URI.decode_www_form("a&b"))
   end
+
+  def test_escape
+    assert_equal("http://example.com/?a=%09%0D", URI.escape("http://example.com/?a=\11\15"))
+    assert_equal("@%3F@%21", URI.escape("@?@!", "!?"))
+  end
+
+  def test_unescape
+    assert_equal("http://example.com/?a=\t\r", URI.unescape("http://example.com/?a=%09%0D"))
+  end
 end
 
 MTest::Unit.new.run


### PR DESCRIPTION
escape(str [, unsafe]), and unescape(str) are not working.

```
> URI.escape('foo bar')
(mirb):1: undefined method 'arg' (NoMethodError)
> URI.unescape('foo%20bar')
(mirb):2: undefined method 'arg' (NoMethodError)
```